### PR TITLE
fix: wrangler.tomlのmainパスをcloudflare-pages出力に修正

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,7 @@
 
 # プロジェクト基本設定
 name = "pomodoro-timer"
-main = ".output/server/index.mjs"
+main = "dist/_worker.js/index.js"
 compatibility_date = "2025-07-15"
 compatibility_flags = ["nodejs_compat"]
 


### PR DESCRIPTION
Nitro cloudflare-pagesプリセットの出力ファイルパス
dist/_worker.js/index.js に合わせてmainフィールドを更新

🤖 Generated with [Claude Code](https://claude.ai/code)