### PR TITLE
fix: 本番環境のWorker名をpomodoro-timer-productionに修正

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -9,8 +9,8 @@ compatibility_flags = ["nodejs_compat"]
 
 # 本番環境設定（mainブランチ）
 [env.production]
-name = "pomodoro-timer"
-# workers.devサブドメインを使用: pomodoro-timer.your-account.workers.dev
+name = "pomodoro-timer-production"
+# workers.devサブドメインを使用: pomodoro-timer-production.your-account.workers.dev
 
 # 開発環境設定（developブランチ）
 [env.develop] 


### PR DESCRIPTION
基本設定との名前重複を解決し、開発・本番環境を明確に分離

🤖 Generated with [Claude Code](https://claude.ai/code)