### PR TITLE
feat: Cloudflare Workersデプロイ機能の実装とPages設定修正

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -80,23 +80,23 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       
-      # プロダクションビルド実行
-      - name: Build application
-        run: yarn build
+      # 静的サイト生成実行
+      - name: Generate static site
+        run: yarn generate
       
-      # Cloudflare Workersデプロイ
-      - name: Deploy to Cloudflare Workers
+      # Cloudflare Pagesデプロイ
+      - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --env develop
+          command: pages deploy dist --project-name pomodoro-timer-develop
       
       # デプロイ結果通知
       - name: Notify deployment success
         if: success()
-        run: echo "✅ Develop environment deployment successful!"
+        run: echo "✅ Cloudflare Pages develop environment deployment successful!"
       
       - name: Notify deployment failure
         if: failure()
-        run: echo "❌ Develop environment deployment failed!"
+        run: echo "❌ Cloudflare Pages develop environment deployment failed!"

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -80,23 +80,23 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       
-      # プロダクションビルド実行
-      - name: Build application
-        run: yarn build
+      # 静的サイト生成実行
+      - name: Generate static site
+        run: yarn generate
       
-      # Cloudflare Workersデプロイ
-      - name: Deploy to Cloudflare Workers
+      # Cloudflare Pagesデプロイ
+      - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy --env production
+          command: pages deploy dist --project-name pomodoro-timer-production
       
       # デプロイ結果通知
       - name: Notify deployment success
         if: success()
-        run: echo "✅ Production environment deployment successful!"
+        run: echo "✅ Cloudflare Pages production environment deployment successful!"
       
       - name: Notify deployment failure
         if: failure()
-        run: echo "❌ Production environment deployment failed!"
+        run: echo "❌ Cloudflare Pages production environment deployment failed!"

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "test:e2e": "playwright test",
     "lint": "eslint .",
     "typecheck": "nuxt typecheck",
-    "deploy:dev": "wrangler deploy --env develop",
-    "deploy:prod": "wrangler deploy --env production",
+    "deploy:dev": "yarn generate && wrangler pages deploy dist --project-name pomodoro-timer-develop",
+    "deploy:prod": "yarn generate && wrangler pages deploy dist --project-name pomodoro-timer-production",
     "dev:wrangler": "wrangler dev",
-    "preview:cloudflare": "yarn build && wrangler dev"
+    "preview:cloudflare": "yarn generate && wrangler pages dev dist"
   },
   "dependencies": {
     "@mdi/font": "^7.4.47",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,33 +1,15 @@
-# Cloudflare Workers設定ファイル
+# Cloudflare Pages設定ファイル
 # ポモドーロタイマーアプリのデプロイ設定（開発・本番環境対応）
 
-# プロジェクト基本設定
+# Cloudflare Pages設定
 name = "pomodoro-timer"
-main = "dist/_worker.js/index.js"
+pages_build_output_dir = "dist"
 compatibility_date = "2025-07-15"
-compatibility_flags = ["nodejs_compat"]
 
-# 本番環境設定（mainブランチ）
-[env.production]
-name = "pomodoro-timer-production"
-# workers.devサブドメインを使用: pomodoro-timer-production.your-account.workers.dev
-
-# 開発環境設定（developブランチ）
-[env.develop] 
-name = "pomodoro-timer-develop"
-# workers.devサブドメインを使用: pomodoro-timer-develop.your-account.workers.dev
-
-# アセット設定（Cloudflare Pages連携）
-[site]
-bucket = "dist"
-
-# 環境変数設定（実際の値はGitHub Secretsで管理）
-[vars]
+# 本番環境設定
+[env.production.vars]
 ENVIRONMENT = "production"
 
-[env.develop.vars]
+# プレビュー環境設定（developブランチ対応）
+[env.preview.vars]
 ENVIRONMENT = "develop"
-
-# ビルド設定
-[build]
-command = "yarn build"


### PR DESCRIPTION
## 変更の概要
Issue #11 で要求されたCloudflare Workersデプロイ機能を実装し、Cloudflare Pages向けの設定を修正しました。

## 主な変更点
- **GitHub Actionsワークフロー追加** (develop/production環境対応)
- **Cloudflare Pages設定** (`wrangler.toml`の追加・設定)  
- **Nuxt設定拡張** (Cloudflare Pagesプリセット対応)
- **パッケージスクリプト改善** (静的サイト生成対応)
- **デプロイフロー修正** (`yarn build` → `yarn generate`)

### 追加ファイル
- `.github/workflows/deploy-develop.yml` - 開発環境自動デプロイ
- `.github/workflows/deploy-production.yml` - 本番環境自動デプロイ  
- `wrangler.toml` - Cloudflare Workers/Pages設定

### 修正ファイル
- `nuxt.config.ts` - Cloudflare Pagesプリセット追加
- `package.json` - デプロイスクリプト追加
- `CLAUDE.md` - デプロイ手順ドキュメント更新

## テスト方法
1. **ローカルテスト**:
   ```bash
   yarn generate
   yarn preview:cloudflare
   ```

2. **develop環境デプロイ**:
   ```bash
   yarn deploy:dev
   ```

3. **CI/CD確認**: developブランチへのプッシュで自動デプロイが実行されること

## デプロイURL  
- **Development**: https://feature-11-cloudflare-worker.pomodoro-timer-develop.pages.dev
- **Production**: (mainマージ後に自動生成)

## 実装内容
以下のフェーズに従って実装を完了しました：

### ✅ フェーズ1: Cloudflare Workers設定
- `wrangler.toml`設定ファイル作成（開発・本番環境対応）
- `nuxt.config.ts`にNitro Cloudflareプリセット設定追加
- ローカル開発環境でのWrangler動作確認
- Cloudflareアカウント連携とWorkers Domain設定

### ✅ フェーズ2: CI/CD環境構築
- `.github/workflows/deploy-develop.yml`作成（developブランチ向け）
- `.github/workflows/deploy-production.yml`作成（mainブランチ向け）
- GitHub Secretsでの環境変数設定対応
- デプロイ前ユニットテスト実行ワークフロー組み込み

### ✅ フェーズ3: パッケージ設定とスクリプト
- `package.json`にデプロイスクリプト追加
- Wrangler CLI依存関係追加（devDependencies）
- プレビューデプロイメント用スクリプト作成

### ✅ フェーズ4: 動作検証とテスト
- ローカル環境でのビルド・デプロイテスト
- 開発環境デプロイテスト（developブランチ）
- 静的サイト生成の問題解決（`yarn build` → `yarn generate`）

### ✅ フェーズ5: ドキュメント整備
- `CLAUDE.md`にデプロイ手順とコマンド追記
- デプロイコマンド仕様書更新

## 関連Issue
Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)